### PR TITLE
chore: lint-staged 및 biome 설정 개선

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,8 @@
 {
   "$schema": "node_modules/@biomejs/biome/configuration_schema.json",
+  "files": {
+    "includes": ["**", "!src/components/ui"]
+  },
   "linter": {
     "domains": {
       "next": "recommended",

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,0 +1,28 @@
+import biome from "./biome.json" with { type: "json" };
+
+/**
+ * @param {string} file
+ * @returns {boolean}
+ */
+const isBiomeIncluded = (file) => {
+  return !biome.files.includes.some((pattern) => {
+    return pattern.startsWith("!") && file.match(pattern.slice(1));
+  });
+};
+
+/**
+ * @type {import("lint-staged").Configuration}
+ */
+export default {
+  "*.{css,js,ts,jsx,tsx,json}": (files) => {
+    const args = [
+      "--write",
+      "--unsafe",
+      "--no-errors-on-unmatched",
+      "--files-ignore-unknown=true",
+    ];
+    const filtered = files.filter(isBiomeIncluded);
+    return [`biome check ${args.join(" ")} ${filtered.join(" ")}`];
+  },
+  "package.json": "sort-package-json",
+};

--- a/package.json
+++ b/package.json
@@ -16,12 +16,6 @@
   "simple-git-hooks": {
     "pre-commit": "yarn run lint-staged"
   },
-  "lint-staged": {
-    "*.{css,js,ts,jsx,tsx,json}": [
-      "biome check --write --unsafe"
-    ],
-    "package.json": "sort-package-json"
-  },
   "dependencies": {
     "@tanstack/react-query": "^5.74.3",
     "@tanstack/react-query-devtools": "^5.74.3",


### PR DESCRIPTION
## 내용

- `shadcn/ui`으로 자동 생성되는 파일들은 lint, format에서 제외하기 위해 biome 설정을 보완헀습니다.
- biome 설정을 진행하더라도 git hook이 실행될 때 cli arguments로 명시적으로 전달되는 파일들은 다시 포함되는 문제가 있어, biome 설정을 따르도록 `lint-staged` 구성을 보완했습니다.