### PR TITLE
chore: 메인 페이지 카드 스타일 수정

### DIFF
--- a/src/components/present-recommendation-content/header-section/index.tsx
+++ b/src/components/present-recommendation-content/header-section/index.tsx
@@ -32,7 +32,7 @@ export const HeaderSection = ({
         ease: "easeInOut",
       }}
     >
-      <Page.Title className="mt-48px font-bold text-gray-100 text-heading-24-semibold">
+      <Page.Title className="mt-[60px] text-gray-100">
         딱 맞는 선물, 함께 골라볼까요?
       </Page.Title>
     </motion.div>
@@ -49,7 +49,7 @@ export const HeaderSection = ({
         ease: "easeInOut",
       }}
     >
-      <Page.SubTitle className="mt-16px font-medium text-heading-20-semibold text-white">
+      <Page.SubTitle className="mt-8px text-white">
         질문을 풀며 원하는 선물을 찾아가요
       </Page.SubTitle>
     </motion.div>

--- a/src/components/present-recommendation-content/present-box-section/index.tsx
+++ b/src/components/present-recommendation-content/present-box-section/index.tsx
@@ -3,7 +3,7 @@
 import { motion } from "framer-motion";
 import Image from "next/image";
 import { useEffect, useState } from "react";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/shared/button";
 
 const CARD_WIDTH = 274;
 const CARD_HEIGHT = 399;
@@ -105,7 +105,7 @@ export const PresentBoxSection = ({
       scale: 1,
       borderRadius: CARD_BORDER_RADIUS,
       zIndex: 10,
-      backgroundColor: "white",
+      backgroundColor: "rgba(255, 255, 255, 0.9)",
     },
     expanded: {
       ...(isMobile ? mobileExpandedStyles : desktopExpandedStyles),
@@ -157,7 +157,7 @@ export const PresentBoxSection = ({
             height: `${IMAGE_CONTAINER_SIZE}px`,
             width: `${IMAGE_CONTAINER_SIZE}px`,
           }}
-          className="mb-6"
+          className="mb-12px"
         />
 
         <motion.div
@@ -165,13 +165,16 @@ export const PresentBoxSection = ({
           animate={isNextStepButtonClicked ? "expanded" : "normal"}
           className="w-full"
         >
-          <p className="mb-4 font-bold text-black">오늘의 선물 꾸러미</p>
+          <p className="mb-[18px] text-body-16-bold text-gray-600">
+            오늘의 선물 꾸러미
+          </p>
           <Button
+            size="large"
+            className="w-full"
             onClick={onClickNextStepButton}
             disabled={isNextStepButtonClicked}
-            className="min-h-[48px] w-full rounded-[21px] bg-black py-4 font-bold text-foreground text-xl"
           >
-            지금 선물하기
+            <span className="text-gray-100">지금 선물하기</span>
           </Button>
         </motion.div>
       </motion.div>

--- a/src/components/shared/button/index.tsx
+++ b/src/components/shared/button/index.tsx
@@ -2,7 +2,7 @@ import { ComponentProps, PropsWithChildren } from "react";
 import { cn } from "@/lib/utils";
 
 interface Props extends ComponentProps<"button"> {
-  size?: "medium" | "x-large" | "keyboard";
+  size?: "medium" | "large" | "x-large" | "keyboard";
   variant?: "contained";
 }
 
@@ -21,6 +21,9 @@ export const Button = ({
         styles,
         "rounded-[8px] px-48px py-16px text-subtitle-18-medium",
       );
+      break;
+    case "large":
+      styles = cn(styles, "rounded-[12px] px-48px py-[17px] text-body-16-bold");
       break;
     case "x-large":
       styles = cn(

--- a/src/components/shared/page/index.tsx
+++ b/src/components/shared/page/index.tsx
@@ -78,15 +78,9 @@ Page.Title = ({ children, className }: Props) => {
 
 Page.SubTitle = ({ children, className }: Props) => {
   return (
-    <h2 className={cn("text-center text-body-16-regular", className)}>
+    <h2 className={cn("text-center text-subtitle-18-medium", className)}>
       {children}
     </h2>
-  );
-};
-
-Page.SubTitle = ({ children, className }: Props) => {
-  return (
-    <h2 className={cn("text-center text-body-2", className)}>{children}</h2>
   );
 };
 


### PR DESCRIPTION
## 내용

메인 페이지의 카드 스타일을 디자인에 맞게 조금씩 수정을 진행했어요.

| as-is | to-be |
| - | - |
| ![CleanShot 2025-05-12 at 23 53 25](https://github.com/user-attachments/assets/b9835bd3-5fd4-4107-a06a-37380daf2179) | ![CleanShot 2025-05-12 at 23 53 40](https://github.com/user-attachments/assets/8de6be62-04c7-481f-884d-55c280ac392d) |
