### PR TITLE
feat: 이름 설정 페이지 구현

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -72,7 +72,7 @@ export default async function Home() {
                 className="text-black hover:bg-transparent"
               >
                 <Image
-                  src="footer-navigation/star.svg"
+                  src="/footer-navigation/star.svg"
                   alt="logo"
                   width={25}
                   height={25}
@@ -84,7 +84,7 @@ export default async function Home() {
                 className="text-black hover:bg-transparent"
               >
                 <Image
-                  src="footer-navigation/user.svg"
+                  src="/footer-navigation/user.svg"
                   alt="logo"
                   width={35}
                   height={35}

--- a/src/app/recommendation/setup/name/page.tsx
+++ b/src/app/recommendation/setup/name/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Search } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { FooterToggle } from "@/components/layout/footer-toggle";
+import { Page } from "@/components/shared/page";
+import { Button } from "@/components/ui/button";
+
+export default function RecommendationSetupNamePage() {
+  return (
+    <Page className="bg-[linear-gradient(155deg,_#6299ff_44%,_#a6d6ff_93%)]">
+      <Page.Header>
+        <Page.Header.Left>
+          <Link href="/">
+            <Image src="/logo.svg" alt="logo" width={100} height={100} />
+          </Link>
+        </Page.Header.Left>
+        <Page.Header.Right>
+          <Link href="/">
+            <Search className="text-white" />
+          </Link>
+        </Page.Header.Right>
+      </Page.Header>
+
+      <Page.Container className="flex flex-1 flex-col items-center justify-center pb-[100px]">
+        <div className="mb-[60px] rounded-full bg-white px-[10px] py-[8px] text-[#4282F9] text-body-16-bold">
+          필수 정보 4개
+        </div>
+
+        <Page.Title className="mb-16px font-bold text-white">
+          누구에게 선물하고자 하나요?
+        </Page.Title>
+
+        <Page.SubTitle className="text-gray-100">
+          선물하고자 하는 상대에 대해 알려주세요
+        </Page.SubTitle>
+      </Page.Container>
+
+      <Page.ActionButton>
+        {(props) => (
+          <div className="flex w-full items-center justify-between gap-2">
+            <Button variant="ghost" className="text-black hover:bg-transparent">
+              <Image
+                src="/footer-navigation/star.svg"
+                alt="logo"
+                width={25}
+                height={25}
+              />
+            </Button>
+            <FooterToggle />
+            <Button variant="ghost" className="text-black hover:bg-transparent">
+              <Image
+                src="/footer-navigation/user.svg"
+                alt="logo"
+                width={35}
+                height={35}
+              />
+            </Button>
+          </div>
+        )}
+      </Page.ActionButton>
+    </Page>
+  );
+}

--- a/src/components/layout/footer-toggle/index.tsx
+++ b/src/components/layout/footer-toggle/index.tsx
@@ -58,7 +58,7 @@ export const FooterToggle = () => {
         disabled={isAnimating}
       >
         <Image
-          src="footer-navigation/home.svg"
+          src="/footer-navigation/home.svg"
           alt="logo"
           width={35}
           height={35}
@@ -75,7 +75,7 @@ export const FooterToggle = () => {
         disabled={isAnimating}
       >
         <Image
-          src="footer-navigation/result.svg"
+          src="/footer-navigation/result.svg"
           alt="logo"
           width={35}
           height={35}


### PR DESCRIPTION
## 내용

이름 설정 페이지의 초기 화면을 구현했습니다. 그리고 이미지들이 상대 경로로 깨지는 문제도 같이 수정해두었습니다.

![CleanShot 2025-05-13 at 01 31 11](https://github.com/user-attachments/assets/e66010fb-4dfb-4e9b-bab0-8d139c170488)
