### PR TITLE
refactor: Button 컴포넌트를 class-variance-authority 사용하도록 리팩토링

### DIFF
--- a/src/components/shared/button/index.tsx
+++ b/src/components/shared/button/index.tsx
@@ -1,54 +1,47 @@
+import { cva, type VariantProps } from "class-variance-authority";
 import { ComponentProps, PropsWithChildren } from "react";
 import { cn } from "@/lib/utils";
 
-interface Props extends ComponentProps<"button"> {
-  size?: "medium" | "large" | "x-large" | "keyboard";
-  variant?: "contained";
-}
-
-export const Button = ({
-  size = "medium",
-  variant = "contained",
-  className,
-  children,
-  ...props
-}: PropsWithChildren<Props>) => {
-  let styles = "enabled:cursor-pointer transition-colors";
-
-  switch (size) {
-    case "medium":
-      styles = cn(
-        styles,
-        "rounded-[8px] px-48px py-16px text-subtitle-18-medium",
-      );
-      break;
-    case "large":
-      styles = cn(styles, "rounded-[12px] px-48px py-[17px] text-body-16-bold");
-      break;
-    case "x-large":
-      styles = cn(
-        styles,
-        "rounded-[12px] px-48px py-16px text-subtitle-18-bold",
-      );
-      break;
-    case "keyboard":
-      styles = cn(styles, "px-48px py-16px text-subtitle-18-bold");
-      break;
-  }
-
-  switch (variant) {
-    case "contained":
-      styles = cn(
-        styles,
+const buttonVariants = cva("enabled:cursor-pointer transition-colors", {
+  variants: {
+    size: {
+      medium: "rounded-[8px] px-48px py-16px text-subtitle-18-medium",
+      large: "rounded-[12px] px-48px py-[17px] text-body-16-bold",
+      "x-large": "rounded-[12px] px-48px py-16px text-subtitle-18-bold",
+      keyboard: "px-48px py-16px text-subtitle-18-bold",
+    },
+    variant: {
+      contained: [
         "bg-gray-700 text-gray-300 enabled:[&:not([aria-selected='true'])]:hover:bg-gray-600",
         "disabled:text-gray-500",
         "aria-selected:bg-primary-500 aria-selected:text-gray-700",
-      );
-      break;
-  }
+      ],
+      ghost: "bg-transparent hover:bg-white/10",
+      icon: "flex items-center justify-center h-10 w-10 rounded-full bg-white/20 text-black hover:bg-white/30",
+    },
+  },
+  defaultVariants: {
+    size: "medium",
+    variant: "contained",
+  },
+});
 
+export interface ButtonProps
+  extends ComponentProps<"button">,
+    VariantProps<typeof buttonVariants> {}
+
+export const Button = ({
+  size,
+  variant,
+  className,
+  children,
+  ...props
+}: PropsWithChildren<ButtonProps>) => {
   return (
-    <button className={cn(styles, className)} {...props}>
+    <button
+      className={cn(buttonVariants({ size, variant, className }))}
+      {...props}
+    >
       {children}
     </button>
   );


### PR DESCRIPTION
# 내용

Button 컴포넌트를 `class-variance-authority` 라이브러리의 `cva` util을 사용하도록 리팩토링했어요.
