### PR TITLE
feat: 선물하기 버튼 클릭 시 페이지 이동 구현

### DIFF
--- a/src/components/present-recommendation-content/index.tsx
+++ b/src/components/present-recommendation-content/index.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { motion, useAnimation } from "framer-motion";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { getPresents } from "@/api/Present/get-presents";
 import { HeaderSection } from "@/components/present-recommendation-content/header-section";
@@ -16,9 +17,12 @@ interface PresentRecommendationContentProps {
 export const PresentRecommendationContent = ({
   isMobile,
 }: PresentRecommendationContentProps) => {
+  const router = useRouter();
   const [isNextStepButtonClicked, setIsNextStepButtonClicked] = useState(false);
+
   const handleClickNextStepButton = () => {
     setIsNextStepButtonClicked(true);
+    setTimeout(() => router.push("/recommendation/init"), 1_000);
   };
 
   const { data: presents } = useQuery({


### PR DESCRIPTION
## 내용

메인 페이지의 선물하기 버튼을 클릭하면 `/recommendation/init` 페이지로 이동되도록 구현했습니다.

![CleanShot 2025-05-18 at 21 02 35](https://github.com/user-attachments/assets/b8a811d0-9418-4f7d-a390-3a35e879b83f)
