### PR TITLE
feat: /auth/settings 페이지 추가, /auth/sign-in 수정

### DIFF
--- a/src/app/auth/settings/page.tsx
+++ b/src/app/auth/settings/page.tsx
@@ -1,0 +1,14 @@
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+const AuthSettingsPage = async () => {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    const params = new URLSearchParams({ callbackUrl: "/auth/settings" });
+    return redirect(`/auth/sign-in?${params}`);
+  }
+};
+
+export default AuthSettingsPage;

--- a/src/app/auth/sign-in/page.tsx
+++ b/src/app/auth/sign-in/page.tsx
@@ -12,8 +12,9 @@ const SignInPage = async () => {
   if (session) {
     redirect("/");
   }
+
   return (
-    <Page className="bg-signInBackground">
+    <Page className="bg-sign-in">
       <Page.Header>
         <Page.Header.Right>
           <Back label="닫기" />

--- a/src/components/auth/sign-in/index.tsx
+++ b/src/components/auth/sign-in/index.tsx
@@ -11,8 +11,8 @@ interface Props {
 export const SignInButton = ({ callback }: Props) => {
   const params = useSearchParams();
   const callbackUrl = params.get("callbackUrl") ?? "/";
-
   const { login } = useKakaoSignIn({ callbackUrl: callback ?? callbackUrl });
+
   return (
     <Button
       size="large"

--- a/src/components/layout/bottom-bar/index.tsx
+++ b/src/components/layout/bottom-bar/index.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import Image, { ImageProps } from "next/image";
+import { useRouter } from "next/navigation";
+import { PropsWithChildren } from "react";
 import { BottomBarTabs } from "@/components/layout/bottom-bar/bottom-bar-tabs";
 import { cn } from "@/lib/utils";
 
@@ -9,12 +11,31 @@ interface Props {
 }
 
 export const BottomBar = ({ className }: Props) => {
+  const router = useRouter();
+
   return (
     <div className={cn("flex w-full items-center justify-between", className)}>
       <StarIcon width={25} height={25} />
       <BottomBarTabs />
-      <UserIcon width={35} height={35} />
+      <IconButton onClick={() => router.push("/auth/settings")}>
+        <UserIcon width={35} height={35} />
+      </IconButton>
     </div>
+  );
+};
+
+const IconButton = ({
+  onClick,
+  children,
+}: PropsWithChildren<{ onClick: () => void }>) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex items-center justify-center p-8px"
+    >
+      {children}
+    </button>
   );
 };
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -67,7 +67,7 @@ export const authOptions: NextAuthOptions = {
   },
 
   pages: {
-    signIn: "/auth/signIn",
+    signIn: "/auth/sign-in",
     error: "/auth/error",
   },
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,6 +10,12 @@ const isProtectedRoute = (path: string) => {
   );
 };
 
+export const config = {
+  matcher: [
+    "/((?!api|_next/static|_next/image|favicon.ico|auth|mockServiceWorker.js|.*\\.png$|.*\\.svg$|$).*)",
+  ],
+};
+
 export default withAuth(
   function middleware() {
     return NextResponse.next();
@@ -23,15 +29,8 @@ export default withAuth(
         return true;
       },
     },
-
     pages: {
-      signIn: "/auth/signIn",
+      signIn: "/auth/sign-in",
     },
   },
 );
-
-export const config = {
-  matcher: [
-    "/((?!api|_next/static|_next/image|favicon.ico|auth|mockServiceWorker.js|.*\\.png$|.*\\.svg$|$).*)",
-  ],
-};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -27,7 +27,7 @@ const config: Config = {
       },
       white: "#FFFFFF",
       kakao: "#FEDC00",
-      signInBackground: "#f9fafd",
+      "sign-in": "#f9fafd",
     },
     fontSize: {
       "display-32-semibold": [


### PR DESCRIPTION
## 내용

User 아이콘을 클릭할 경우 `/auth/settings` 페이지로 이동하도록 구현했습니다.

![CleanShot 2025-05-18 at 21 29 20](https://github.com/user-attachments/assets/bf758be0-4681-4707-b8a0-2558b0069ffc)


`/auth/settings` 페이지의 session 처리 쪽만 구현하고, `/auth/signIn` 페이지를 `/auth/sign-in` 페이지로 변경 및 일부 리팩토링을 진행했습니다.