### PR TITLE
feat: 프로필 설정 (수정) 페이지 구현

### DIFF
--- a/src/app/auth/settings/edit/page.tsx
+++ b/src/app/auth/settings/edit/page.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import type { PropsWithChildren } from "react";
+import { SignOutButton } from "@/components/auth/sign-out";
 import { Back } from "@/components/shared/back";
 import { Page } from "@/components/shared/page";
 import { authOptions } from "@/lib/auth";
@@ -55,9 +56,11 @@ const AuthSettingsEditPage = async () => {
       <div className="h-8px w-full bg-gray-700" />
 
       <Page.Container className="flex py-12px">
-        <PersonButton>로그아웃</PersonButton>
+        <SignOutButton>
+          <PersonButton>로그아웃</PersonButton>
+        </SignOutButton>
         <div className="mx-8px h-[48px] w-[1px] bg-gray-700" />
-        <PersonButton>회원탈퇴</PersonButton>
+        <PersonButton disabled>회원탈퇴</PersonButton>
       </Page.Container>
     </Page>
   );
@@ -75,13 +78,18 @@ PersonInfo.Value = ({ children }: PropsWithChildren) => {
   return <p className="text-gray-100 text-subtitle-16-semibold">{children}</p>;
 };
 
-const PersonButton = ({ children }: PropsWithChildren) => {
+const PersonButton = ({
+  disabled,
+  children,
+}: PropsWithChildren<{ disabled?: boolean }>) => {
   return (
     <button
       type="button"
+      disabled={disabled}
       className={cn(
-        "w-full rounded-[8px] text-gray-100 text-subtitle-16-semibold transition-colors",
-        "hover:bg-gray-700 hover:text-white",
+        "w-full rounded-[8px] text-subtitle-16-semibold transition-colors",
+        !disabled && "hover:bg-gray-700 hover:text-white",
+        disabled ? "text-gray-500" : "text-gray-100",
       )}
     >
       {children}

--- a/src/app/auth/settings/edit/page.tsx
+++ b/src/app/auth/settings/edit/page.tsx
@@ -1,0 +1,92 @@
+import Image from "next/image";
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import type { PropsWithChildren } from "react";
+import { Back } from "@/components/shared/back";
+import { Page } from "@/components/shared/page";
+import { authOptions } from "@/lib/auth";
+import { cn } from "@/lib/utils";
+
+const AuthSettingsEditPage = async () => {
+  const session = await getServerSession(authOptions);
+
+  if (!session || !session.user) {
+    const params = new URLSearchParams({ callbackUrl: "/auth/settings" });
+    return redirect(`/auth/sign-in?${params}`);
+  }
+
+  const image =
+    session.user.image || "/static/images/auth-settings-profile.svg";
+
+  return (
+    <Page className="bg-gray-800">
+      <Page.Header>
+        <Page.Header.Left>
+          <Back />
+        </Page.Header.Left>
+        <Page.Header.Center className="text-body-16-regular text-gray-100">
+          프로필 수정
+        </Page.Header.Center>
+      </Page.Header>
+
+      <Page.Container className="flex justify-center py-32px">
+        <Image
+          src={image}
+          alt="profile"
+          width={92}
+          height={92}
+          className="rounded-full"
+        />
+      </Page.Container>
+
+      <Page.Container className="pb-24px">
+        <section className="flex flex-col gap-12px rounded-[14px] bg-gray-700 p-24px">
+          <PersonInfo>
+            <PersonInfo.Label>이름</PersonInfo.Label>
+            <PersonInfo.Value>{session.user.name}</PersonInfo.Value>
+          </PersonInfo>
+          <PersonInfo>
+            <PersonInfo.Label>이메일</PersonInfo.Label>
+            <PersonInfo.Value>{session.user.email}</PersonInfo.Value>
+          </PersonInfo>
+        </section>
+      </Page.Container>
+
+      <div className="h-8px w-full bg-gray-700" />
+
+      <Page.Container className="flex py-12px">
+        <PersonButton>로그아웃</PersonButton>
+        <div className="mx-8px h-[48px] w-[1px] bg-gray-700" />
+        <PersonButton>회원탈퇴</PersonButton>
+      </Page.Container>
+    </Page>
+  );
+};
+
+const PersonInfo = ({ children }: PropsWithChildren) => {
+  return <div className="flex justify-between">{children}</div>;
+};
+
+PersonInfo.Label = ({ children }: PropsWithChildren) => {
+  return <p className="text-body-16-regular text-gray-500">{children}</p>;
+};
+
+PersonInfo.Value = ({ children }: PropsWithChildren) => {
+  return <p className="text-gray-100 text-subtitle-16-semibold">{children}</p>;
+};
+
+const PersonButton = ({ children }: PropsWithChildren) => {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "w-full rounded-[8px] text-gray-100 text-subtitle-16-semibold transition-colors",
+        "hover:bg-gray-700 hover:text-white",
+      )}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default AuthSettingsEditPage;

--- a/src/app/auth/settings/page.tsx
+++ b/src/app/auth/settings/page.tsx
@@ -5,6 +5,7 @@ import { getServerSession } from "next-auth";
 import { BottomBar } from "@/components/layout/bottom-bar";
 import { Page } from "@/components/shared/page";
 import { authOptions } from "@/lib/auth";
+import { cn } from "@/lib/utils";
 
 const items = [
   {
@@ -77,41 +78,50 @@ const AuthSettingsPage = async () => {
           <Link href="/auth/settings/edit">
             <button
               type="button"
-              className="rounded-[8px] bg-gray-700 px-12px py-[6px] text-gray-300"
+              className={cn(
+                "rounded-[8px] bg-gray-700 px-12px py-[6px] text-gray-300 transition-all",
+                "hover:bg-gray-600/50 hover:text-gray-200",
+              )}
             >
               프로필 수정
             </button>
           </Link>
         </section>
-
-        {items.map((category) => (
-          <section key={category.title} className="mb-[36px]">
-            <h2 className="mb-4px py-8px text-gray-100 text-subtitle-18-semibold">
-              {category.title}
-            </h2>
-            {category.links.map(({ image, name, url }) => (
-              <Link
-                key={name}
-                href={url}
-                className="mb-4px flex items-center justify-between py-8px"
-              >
-                <div className="flex items-center gap-8px">
-                  <Image src={image} alt={name} width={24} height={24} />
-                  <span className="text-body-16-regular text-gray-100">
-                    {name}
-                  </span>
-                </div>
-                <Image
-                  src="/static/images/arrow-right-icon.svg"
-                  alt="arrow-right-icon"
-                  width={20}
-                  height={20}
-                />
-              </Link>
-            ))}
-          </section>
-        ))}
       </Page.Container>
+
+      {items.map((category) => (
+        <Page.Container
+          key={category.title}
+          as="section"
+          className="mb-[36px] px-8px"
+          noPadding
+        >
+          <h2 className="mb-4px px-8px py-8px text-gray-100 text-subtitle-18-semibold">
+            {category.title}
+          </h2>
+          {category.links.map(({ image, name, url }) => (
+            <Link
+              key={name}
+              href={url}
+              className={cn(
+                "mb-4px flex items-center justify-between rounded-[8px] px-8px py-8px text-gray-100 transition-all",
+                "hover:scale-[1.01] hover:bg-gray-700 hover:text-white",
+              )}
+            >
+              <div className="flex items-center gap-8px">
+                <Image src={image} alt={name} width={24} height={24} />
+                <span className="text-body-16-regular">{name}</span>
+              </div>
+              <Image
+                src="/static/images/arrow-right-icon.svg"
+                alt="arrow-right-icon"
+                width={20}
+                height={20}
+              />
+            </Link>
+          ))}
+        </Page.Container>
+      ))}
 
       <Page.ActionButton>
         {(props) => <BottomBar {...props} />}

--- a/src/components/auth/sign-out/index.tsx
+++ b/src/components/auth/sign-out/index.tsx
@@ -1,19 +1,56 @@
 "use client";
 
-import { LogOut } from "lucide-react";
 import { signOut } from "next-auth/react";
+import { type PropsWithChildren, useState } from "react";
+import { Button } from "@/components/shared/button";
+import { Page } from "@/components/shared/page";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
 
-import { Button } from "@/components/ui/button";
+interface Props {
+  onSignOut?: () => Promise<void>;
+}
 
-export const SignOutButton = () => {
-  const handleSignOut = () => {
-    signOut();
-  };
+export const SignOutButton = ({
+  onSignOut,
+  children,
+}: PropsWithChildren<Props>) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleSignOut = onSignOut || (() => signOut({ callbackUrl: "/" }));
 
   return (
-    <Button onClick={handleSignOut}>
-      <LogOut className="size-4" />
-      로그아웃
-    </Button>
+    <>
+      <Sheet open={isOpen} onOpenChange={setIsOpen}>
+        <SheetTrigger asChild>{children}</SheetTrigger>
+        <SheetContent
+          side="bottom"
+          showCloseButton={false}
+          className="flex flex-col items-center rounded-t-[24px] border-none bg-gray-700 px-16px py-[56px]"
+        >
+          <SheetHeader>
+            <SheetTitle className="pb-24px text-gray-100 text-heading-20-semibold">
+              로그아웃 하시겠어요?
+            </SheetTitle>
+          </SheetHeader>
+
+          <Page.Container noPadding className="grid grid-cols-2 gap-8px">
+            <Button
+              onClick={() => setIsOpen(false)}
+              className="bg-gray-900 hover:bg-gray-800"
+            >
+              취소
+            </Button>
+            <Button onClick={handleSignOut} aria-selected={true}>
+              로그아웃
+            </Button>
+          </Page.Container>
+        </SheetContent>
+      </Sheet>
+    </>
   );
 };

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -21,7 +21,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0px z-50 bg-black/80 data-[state=closed]:animate-out data-[state=open]:animate-in",
+      "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0px z-50 bg-[#000000]/80 data-[state=closed]:animate-out data-[state=open]:animate-in",
       className,
     )}
     {...props}


### PR DESCRIPTION
## 내용

프로필 정보 페이지에 소소하게 애니메이션(인터랙션)을 추가하고, 수정 페이지 및 로그아웃 기능을 구현했습니다.

회원탈퇴의 경우 아직 API가 존재하지 않아 버튼을 비활성화로 막아만 두었습니다.

| 사진 1 | 사진 2 |
| - | - |
| ![CleanShot 2025-05-27 at 01 15 50](https://github.com/user-attachments/assets/08f22d60-766d-443d-b3f2-d24072c04dd7) | ![CleanShot 2025-05-27 at 01 16 11](https://github.com/user-attachments/assets/33617dfe-db7e-4831-a09d-0eb780cf7823) |

