### PR TITLE
feat: deviceId

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "tailwind-merge": "^3.2.0",
     "tailwindcss-animate": "^1.0.7",
     "ua-parser-js": "^2.0.3",
+    "uuid": "^11.1.0",
     "vaul": "^1.1.2",
     "zod": "^3.24.3"
   },

--- a/src/app/recommendation/init/page.tsx
+++ b/src/app/recommendation/init/page.tsx
@@ -12,6 +12,7 @@ import { PageError } from "@/components/shared/page-error";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
+import { setDeviceId } from "@/utils/device-id";
 import { createUrlFromSessionResponse } from "@/utils/recommendation";
 
 type Phase = "active" | "exiting" | "complete";
@@ -162,10 +163,15 @@ const RecommendationInitComplete = ({ name }: { name: string }) => {
       return;
     }
 
+    const deviceId = setDeviceId();
+    if (typeof deviceId !== "string") {
+      return;
+    }
+
     const start = async () => {
       try {
         const { data } = await mutation.mutateAsync({
-          data: { deviceId: "0000", receiverName: name },
+          data: { deviceId: deviceId, receiverName: name },
         });
 
         if ("sessionId" in data) {

--- a/src/hooks/useKakaoSignIn.ts
+++ b/src/hooks/useKakaoSignIn.ts
@@ -1,4 +1,5 @@
 import { signIn } from "next-auth/react";
+import { getDeviceId } from "@/utils/device-id";
 
 interface UseKakaoSignInProps {
   onError?: (error: unknown) => void;
@@ -11,6 +12,16 @@ export const useKakaoSignIn = ({
 }: UseKakaoSignInProps = {}) => {
   const login = async () => {
     try {
+      const deviceId = getDeviceId();
+
+      if (deviceId) {
+        const cookieName = "nextauth_deviceId";
+        const cookieValue = encodeURIComponent(deviceId);
+        const maxAgeInSeconds = 5 * 60;
+        const path = "/";
+        document.cookie = `${cookieName}=${cookieValue}; path=${path}; max-age=${maxAgeInSeconds}; SameSite=Lax`;
+      }
+
       await signIn("kakao", {
         callbackUrl: `${window.location.origin}${callbackUrl}`,
         redirect: true,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,3 +1,4 @@
+import { cookies } from "next/headers";
 import type { NextAuthOptions } from "next-auth";
 import KakaoProvider from "next-auth/providers/kakao";
 import { authControllerLoginWithSocial } from "@/api/__generated__";
@@ -21,10 +22,14 @@ export const authOptions: NextAuthOptions = {
     async jwt({ token, account }) {
       if (token.sub) {
         try {
+          const cookieStore = await cookies();
+          const deviceId = cookieStore.get("nextauth_deviceId")?.value;
+
           const loginCommand: SocialLoginCommand = {
             snsId: token.sub,
             nickname: token.name ?? "",
             profileImageUrl: token.picture ?? "",
+            deviceId,
           };
 
           const response = await authControllerLoginWithSocial(loginCommand, {

--- a/src/utils/device-id/index.tsx
+++ b/src/utils/device-id/index.tsx
@@ -1,0 +1,33 @@
+import { v4 as uuidv4 } from "uuid";
+
+const DEVICE_ID_KEY = "deviceId";
+
+export const getDeviceId = () => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const deviceId = localStorage.getItem(DEVICE_ID_KEY);
+  return deviceId;
+};
+
+export const setDeviceId = () => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  let deviceId = localStorage.getItem(DEVICE_ID_KEY);
+  if (!deviceId) {
+    deviceId = uuidv4();
+    localStorage.setItem(DEVICE_ID_KEY, deviceId);
+  }
+
+  return deviceId;
+};
+
+export const deleteDeviceId = () => {
+  if (typeof window === "undefined") {
+    return;
+  }
+  localStorage.removeItem(DEVICE_ID_KEY);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5790,6 +5790,11 @@ utrie@^1.0.2:
   dependencies:
     base64-arraybuffer "^1.0.2"
 
+uuid@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
+  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
+
 uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"


### PR DESCRIPTION
## 개요
1. Init 페이지에서 deviceId를 uuid로 생성 하고 요청 본문에 포함시켰습니다.
2. 소셜 로그인 시 deviceId를 요청 본문에 포함시켰습니다.
3. deviceId는 클라이언트 사이드와 서버 사이드에서 각각 참조할 수 있도록 localStorage와 cookie에 저장하였습니다.