### PR TITLE
fix: toast 포지션을 bottom-center로 설정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -50,7 +50,7 @@ export default function RootLayout({ children }: PropsWithChildren) {
     <html lang="en">
       <body className={cn(Pretendard.variable)}>
         <Providers>{children}</Providers>
-        <Toaster />
+        <Toaster position="bottom-center" />
       </body>
       <GoogleAnalytics gaId="G-WZHVL0HJH5" />
     </html>


### PR DESCRIPTION
## 개요
1. Toast의 포지션을 화연 하단 중앙으로 설정하였습니다.
![toast-position](https://github.com/user-attachments/assets/bcd6a374-c8a2-41d6-b624-74e019b3b949)
